### PR TITLE
Fix Always Display Output in Version

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -17,6 +17,9 @@ verbose() {
 
 version() {
   echo "lsusb for macOS 1.1.3"
+
+  # Restore the IFS and exit
+  cleanup
 }
 
 help() {


### PR DESCRIPTION
- Fixes `lsusb -V` always displays output