### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lsusb-test.yml
+++ b/.github/workflows/lsusb-test.yml
@@ -1,5 +1,8 @@
 name: LSUSB Self Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/lsusb/security/code-scanning/33](https://github.com/LanikSJ/lsusb/security/code-scanning/33)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository and runs a script, it likely only needs `contents: read` permission. This will ensure that the workflow has no unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
