### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/lsusb/security/code-scanning/35](https://github.com/LanikSJ/lsusb/security/code-scanning/35)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's tasks, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `security-events: write` for uploading SARIF files (security analysis reports).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`Scan-Build`) to limit permissions to that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
