### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # For non-forks, we will maintain a sibling PR
   restyled:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/lsusb/security/code-scanning/36](https://github.com/LanikSJ/lsusb/security/code-scanning/36)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow interacts with pull requests and repository contents, we can set `contents: read` and `pull-requests: write` permissions. These permissions will ensure the workflow can read repository contents and manage pull requests without granting unnecessary access.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
