### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,9 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # For non-forks, we will maintain a sibling PR
   restyled:
+    permissions:
+      contents: read
+      pull-requests: write
     if: |
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -43,6 +49,8 @@ jobs:
 
   # For forks, we will only run (and print git-am instructions)
   restyled-fork:
+    permissions:
+      contents: read
     if: |
       github.event.action != 'closed' &&
       github.event.pull_request.head.repo.full_name != github.repository
@@ -56,6 +64,9 @@ jobs:
 
   # On closed events clean up any leftover Restyled PRs
   restyled-cleanup:
+    permissions:
+      contents: read
+      pull-requests: write
     if: ${{ github.event.action == 'closed' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/lsusb/security/code-scanning/38](https://github.com/LanikSJ/lsusb/security/code-scanning/38)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For example:
- The `restyled` job likely needs `contents: read` and `pull-requests: write` to manage pull requests.
- The `restyled-fork` job may only need `contents: read`.
- The `restyled-cleanup` job requires `contents: read` and `pull-requests: write` to close pull requests and delete branches.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions for specific tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
