### PR TITLE
Fix manufacturer string scraping

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -74,7 +74,10 @@ parse() {
   # Get the VID
   VID=$(echo "$VID_all" | awk -F ' ' '{print $1}' | sed 's/^ *//; s/ *$//')
   # Get the manufacturer string
-  manufacturer=$(echo "$VID_all" | cut -d ' ' -f 2- | sed 's/^ *//; s/ *$//')
+  manufacturer=$(echo "$device" | grep "Manufacturer" | sed -e 's/Manufacturer: //; s/^ *//g; s/ *$//g;')
+  if [ -z "$manufacturer" ]; then
+    manufacturer=$(echo "$VID_all" | awk -F ' ' '{print $2}' | sed 's/^ *//; s/ *$//')
+  fi
 
   # Get the Location Id
   location=$(echo "$device" | grep "Location ID" | sed -e 's/Location ID://; s/^ *//g; s/ *$//g;')


### PR DESCRIPTION
In OS 26 system_profiler no longer includes manufacturer name in parentheses after VID, but prints it as a separate line item
Account for it to produce correct output