### PR TITLE
fix: repair device parsing, filters, and tree mode on Tahoe and earlier

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -60,7 +60,6 @@ usage() {
   echo "Usage: $(basename "$0") [options]..."
 }
 
-unknown_dev_num=127
 parse() {
   # Get the name of the device, it is the first line that ends with a ':'
   # Trim the string at the end
@@ -76,8 +75,8 @@ parse() {
   VID_all=$(echo "$device" | grep "Vendor ID" | awk -F':' '{print $2}' | sed -e 's/0x//; s/^ *//g' -e 's/ *$//g')
   # Get the VID
   VID=$(echo "$VID_all" | awk -F ' ' '{print $1}' | sed 's/^ *//; s/ *$//')
-  # Get the manufacturer string
-  manufacturer=$(echo "$device" | sed -n 's/^Manufacturer: *//p')
+  # Get the manufacturer string (the line is indented, so allow leading spaces)
+  manufacturer=$(echo "$device" | sed -n 's/^ *Manufacturer: *//p')
   if [ -z "$manufacturer" ]; then
     # Extract vendor name from VID_all (format: "VID (Vendor Name)")
     temp_manufacturer=$(echo "$VID_all" | sed -n 's/.*(\(.*\)).*/\1/p')
@@ -101,9 +100,10 @@ parse() {
   fi
 
   # Get the device number. It's after the '/' in the Location ID, already decimal.
+  # Tahoe no longer reports device numbers; show 000 rather than inventing one.
   device_num=$(echo "$location" | awk -F'/' '{print $2}')
   if [[ -z $device_num ]]; then
-    device_num=$((unknown_dev_num--))
+    device_num=0
   fi
   device_num=$(printf "%03d" "$device_num")
 
@@ -117,13 +117,15 @@ parse() {
     fi
 
     # Get the bus number, in hexadecimal. We'll convert to decimal later.
-    bus_num=$(echo "$device" | grep "Bus Number" | sed -e 's/Bus Number://' -e 's/0x//; s/^ *//g' -e 's/ *$//g')
-    if [[ -z $bus_num ]]; then
-      bus_num="00"
-    fi
+    # Tahoe buses have no Bus Number line; in that case keep the bus number
+    # and Location ID already derived from the bus's Location ID above.
+    bus_hex=$(echo "$device" | grep "Bus Number" | sed -e 's/Bus Number://' -e 's/0x//; s/^ *//g' -e 's/ *$//g')
+    if [[ -n $bus_hex ]]; then
+      bus_num="$bus_hex"
 
-    # Create a fake Location ID for sorting purposes, following the model.
-    locationID="0x${bus_num}000000"
+      # Create a fake Location ID for sorting purposes, following the model.
+      locationID="0x${bus_num}000000"
+    fi
 
     # Device Number is always 1.
     device_num="001"
@@ -132,20 +134,23 @@ parse() {
     VID="05ac"
     manufacturer="(Apple Inc.)"
 
-    # The PID depends on the speed of the hub, which we deduce from the controller driver.
-    PID=$(echo "$device" | grep "Controller Driver" | awk -F':' '{print $2}' | sed -e 's/0x//; s/^ *//g' -e 's/ *$//g; s/.*\(....\)$/\1/')
-    case "$PID" in
-      OHCI)
+    # The PID depends on the speed of the hub, which we deduce from the
+    # controller driver ("Host Controller Driver:" pre-Tahoe, "Driver:" on
+    # Tahoe). Match the controller type anywhere in the driver name; drivers
+    # like AppleEmbeddedUSBXHCIASMedia3142 don't end with it.
+    driver=$(echo "$device" | grep -E "(Controller)? Driver:" | awk -F':' '{print $2}' | tail -1)
+    case "$driver" in
+      *OHCI*)
         PID="8005"
         name="OHCI Root Hub Simulation"
         speed="12M"
         ;;
-      EHCI)
+      *EHCI*)
         PID="8006"
         name="EHCI Root Hub Simulation"
         speed="480M"
         ;;
-      XHCI)
+      *XHCI*)
         PID="8007"
         name="XHCI Root Hub USB 2.0 Simulation"
         speed="5000M"
@@ -160,9 +165,11 @@ parse() {
     bus_num='---'
   fi
 
-  # Strip the parentheses from manufacturer name unless so specified.
-  if [ -z "$parens" ]; then
-    manufacturer=$(echo "$manufacturer" | sed 's/(//; s/)//')
+  # Strip any parentheses from the manufacturer name, then add them back
+  # around the whole name if so specified.
+  manufacturer=$(echo "$manufacturer" | sed 's/(//; s/)//; s/^ *//; s/ *$//')
+  if [ -n "$parens" ] && [ -n "$manufacturer" ]; then
+    manufacturer="($manufacturer)"
   fi
 
   # Include serial number only if available.
@@ -210,14 +217,15 @@ parse() {
       # Convert input bus to lower case
       arg_bus=$(echo "$bus_dev" | awk -F':' '{print $1}' | sed 's/^ *//; s/ *$//')
       if [ -n "$arg_bus" ]; then
-        if [ "$arg_bus" != "$bus_num" ]; then
+        # Compare numerically: the parsed bus number is zero-padded ("008").
+        if [ "$arg_bus" -ne "$bus_num" ]; then
           return 1
         fi
       fi
       # Strip leading and trailing spaces from argument.
       arg_dev=$(echo "$bus_dev" | awk -F':' '{print $2}' | sed 's/^ *//; s/ *$//')
       if [ -n "$arg_dev" ]; then
-        if [ "$arg_dev" != "$device_num" ]; then
+        if [ "$arg_dev" -ne "$device_num" ]; then
           return 1
         fi
       fi
@@ -229,7 +237,7 @@ parse() {
     # Strip leading and trailing spaces from argument.
     arg_dev=$(echo "$bus_dev" | sed 's/^ *//; s/ *$//')
     if [ -n "$arg_dev" ]; then
-      if [ "$arg_dev" != "$device_num" ]; then
+      if [ "$arg_dev" -ne "$device_num" ]; then
         return 1
       fi
     fi
@@ -249,8 +257,13 @@ setup() {
   OIFS=$IFS
   IFS="#"
 
-  # Default exit code is failure, but if we match anything this will change to success.
-  exitcode=1
+  # Without -d/-s filters we always succeed, even with no devices attached
+  # (matches Linux lsusb). With a filter, exit 1 unless something matches.
+  if [ -n "$vid_pid" ] || [ -n "$bus_dev" ]; then
+    exitcode=1
+  else
+    exitcode=0
+  fi
 
   # Flag to know if -t option was set. We ignore filters if so.
   treeflag="no"
@@ -273,9 +286,15 @@ buildtreeline() {
   # So we start each line with the LocationID for sorting purposes, then append the rest of the line as we want it
   # Later, we'll do the sort, then strip off the LocationID for display purposes
 
-  spaces=$(echo "$locationID" | sed 's/^0x...//; s/0//g; s/./ /g; s/.*/&&&&/')
+  # Strip any trailing space left over from the pre-Tahoe "0x... / dev"
+  # location format, so the Location ID is always exactly 10 characters.
+  locationID="${locationID%%+( )}"
+
+  # Indent four spaces per tree level: after the 0x prefix and two-digit
+  # bus number, each nonzero digit is one level deep.
+  spaces=$(echo "$locationID" | sed 's/^0x..//; s/[^1-9a-fA-F]//g; s/./    /g')
   if [ ${#spaces} -eq 0 ]; then
-    spaces=" /:  "
+    spaces="/:  "
   else
     spaces="$spaces|__ "
   fi
@@ -283,8 +302,22 @@ buildtreeline() {
 }
 
 get_devices() {
-  sed <<<"$rawlog" -e '/:$/i\
-#'
+  # Split the log into sections at each "name:" line and emit only the
+  # sections that contain a Product ID line (i.e. actual devices),
+  # separated by '#' lines. Buses are handled by get_buses. This also
+  # excludes the top-level "USB:" header, Tahoe "USB 3.x Bus:" sections
+  # and pre-Tahoe "Media:"/"Volumes:" storage subsections.
+  awk <<<"$rawlog" -v first=1 '
+    function emit() {
+      if (buf ~ /Product ID/) {
+        if (first == 1) { first = 0 } else { print "#" }
+        printf "%s", buf
+      }
+      buf = ""
+    }
+    /:$/ { emit() }
+    { buf = buf $0 "\n" }
+    END { emit() }'
 }
 
 get_buses() {
@@ -316,9 +349,9 @@ tree() {
   # Sort by Location ID.
   treedata=$(echo "$treedata" | sort)
 
-  # Now strip off leading Location ID and print to stdout.
+  # Now strip off the leading 10-character Location ID and print to stdout.
   while IFS= read -r line; do
-    echo -e "$line"
+    printf '%s\n' "${line:10}"
   done <<<"$treedata"
 
   # Restore the IFS
@@ -371,23 +404,19 @@ setup
 # will not be interfered
 
 # Iterate over each entry
-if [ -z "$get_devices" ]; then
-  for device in $(get_devices); do
-    if parse; then
-      # Print the formatted entry
-      echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"
-    fi
-  done
-fi
+for device in $(get_devices); do
+  if parse; then
+    # Print the formatted entry
+    echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"
+  fi
+done
 
-if [ -n "$get_buses" ]; then
-  for device in $(get_buses); do
-    if parse; then
-      # Print the formatted entry
-      echo "Buses:" && echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"
-    fi
-  done
-fi
+for device in $(get_buses); do
+  if parse; then
+    # Print the formatted entry
+    echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"
+  fi
+done
 
 # Restore the IFS and exit
 cleanup

--- a/lsusb
+++ b/lsusb
@@ -100,12 +100,19 @@ parse() {
   fi
 
   # Get the device number. It's after the '/' in the Location ID, already decimal.
-  # Tahoe no longer reports device numbers; show 000 rather than inventing one.
+  # Tahoe no longer reports it there, but the bus address still exists in the
+  # IO Registry, so look it up by Location ID (000 if the device isn't found).
   device_num=$(echo "$location" | awk -F'/' '{print $2}')
-  if [[ -z $device_num ]]; then
-    device_num=0
+  if [[ -z $device_num && -n $location ]]; then
+    if [[ -z $dev_addresses ]]; then
+      dev_addresses=$(get_dev_addresses)
+    fi
+    loc_key="${location#0x}"
+    loc_key="${loc_key##+(0)}"
+    addr_hex=$(awk <<<"$dev_addresses" -v loc="$loc_key" '$1 == loc { print $2; exit }')
+    device_num=$((16#${addr_hex:-0}))
   fi
-  device_num=$(printf "%03d" "$device_num")
+  device_num=$(printf "%03d" "${device_num:-0}")
 
   # Strip off the excess from LocationID for sorting tree.
   locationID=$(echo "$location" | awk -F'/' '{print $1}')
@@ -322,6 +329,22 @@ get_devices() {
 
 get_buses() {
   awk <<<"$rawlog" -v first=1 '/Bus:$/ { flag = 1; if (first == 1) { first = 0 } else { print "#" }; print; next }; /:$/ && flag == 1 { flag = 0 }; flag'
+}
+
+get_dev_addresses() {
+  # Map each device's Location ID to its USB bus address from the IO
+  # Registry. Tahoe's system_profiler no longer reports device numbers
+  # (the pre-Tahoe "Location ID: 0x... / dev" suffix), but the addresses
+  # still exist in the IOUSB plane. Emit one "locationID address" pair
+  # per device, both in hex with the 0x prefix and leading zeros stripped.
+  ioreg -p IOUSB -l -x 2>/dev/null | awk '
+    /"locationID" = 0x/ { loc = $NF; sub(/^0x0*/, "", loc) }
+    /"USB Address" = 0x/ { addr = $NF; sub(/^0x0*/, "", addr) }
+    /^[ |]*}[ ]*$/ {
+      if (loc != "" && addr != "") { print loc " " addr }
+      loc = ""
+      addr = ""
+    }'
 }
 
 tree() {


### PR DESCRIPTION
## Description

On macOS 26 (Tahoe), `lsusb` output is badly degraded, and several options are broken on every macOS version. This PR fixes twelve distinct bugs across device parsing, the flat listing, tree mode, and filtering.

Before (Tahoe 26.5.1, physical Apple Silicon machine, 7 buses / 18 devices):

```text
Bus 000 Device 001: ID 05ac: Apple Inc. USB
Bus 000 Device 001: ID 05ac: Apple Inc. USB 3.1 Bus
Bus 001 Device 124: ID 05e3:0610  USB2.1 Hub  Serial: Not Provided
...
```

After:

```text
Bus 001 Device 000: ID 05e3:0610 GenesysLogic USB2.1 Hub  Serial: Not Provided
...
Bus 001 Device 001: ID 05ac:8007 Apple Inc. XHCI Root Hub USB 2.0 Simulation
```

### Changes Made

All changes are in the `lsusb` script.

Tahoe-specific:

- `get_devices` now only emits sections containing a `Product ID` line. The top-level `USB:` header and `USB 3.x Bus:` sections also end in `:` and were parsed as devices, producing a garbage `ID 05ac:` line and listing every bus with an empty PID and bus number 000. This also excludes pre-Tahoe `Media:`/`Volumes:` storage subsections, which were printed as devices (e.g. `ID 05ac: Apple Inc. NO NAME`).
- Root-hub bus numbers: Tahoe bus sections carry a `Location ID` instead of a `Bus Number` line; derive the bus number from the Location ID when `Bus Number` is absent instead of defaulting to 000.
- Root-hub PID detection: Tahoe uses `Driver:` rather than `Controller Driver:`, and the "last four characters" heuristic broke on drivers like `AppleEmbeddedUSBXHCIASMedia3142` (PID printed as `3142`) and `AppleUSBEHCIPCI` (PID printed as `IPCI`). Match OHCI/EHCI/XHCI anywhere in the driver name.
- Tree mode: the leading 10-character Location ID sort prefix was never stripped from output lines; the indent calculation silently depended on the trailing space of the pre-Tahoe `0x... / dev` location format, so every Tahoe device rendered one level too shallow (hubs appeared as bus roots); `echo -e` could mangle device names. Strip the prefix with `${line:10}`, count nonzero level digits explicitly, and print with `printf`.

All macOS versions:

- The flat-listing bus loop was dead code: it was guarded by `[ -n "$get_buses" ]`, which tests an (undefined) variable rather than calling the function, so buses were never listed. The device loop ran only by the same accident in reverse (`-z` on an undefined variable). Run both loops unconditionally, like tree mode does, and drop the stray `echo "Buses:"` prefix.
- Manufacturer extraction: the sed pattern was anchored to the start of the line, but `system_profiler` indents every line, so the `Manufacturer:` field never matched and every device printed an empty manufacturer.
- `-s` bus/device filtering used string comparison, so `-s 8:` never matched the zero-padded `008` and always exited 1 with no output. Compare numerically with `-ne`, restoring the documented behavior.
- Device numbers: Tahoe no longer reports them in `system_profiler`, and the fabricated countdown from 127 produced numbers that shift between invocations (any device arriving or leaving renumbers everything), so they could not be used with `-s`. The real USB bus addresses still exist in the IO Registry, so when the `/ devnum` suffix is absent, look the device up in the IOUSB plane by Location ID (one lazy `ioreg` call per run; pre-Tahoe never takes this path). These are the genuine enumeration addresses — stable while a device stays connected — so `-s bus:dev` filtering works again on Tahoe with pre-Tahoe/Linux semantics. Devices not found in the registry fall back to `000`.
- `-p` now parenthesizes the manufacturer name as documented; previously it only preserved parentheses that were already present, which (after the manufacturer fix) is never the case for real devices.
- Bare `lsusb` with no `-d`/`-s` filter now always exits 0 even if no devices are attached, matching Linux lsusb. Filters still exit 1 when nothing matches. Previously a bare run only exited 0 because the garbage `USB:` header chunk counted as a match — this change keeps the CI self-test green on virtual runners now that the garbage line is gone.

## Related Issue

No open issue; this follows up on the Tahoe support from #65 and the manufacturer scraping fix from #68, both of which left the issues above on real Tahoe hardware.

## Motivation and Context

The Homebrew-distributed 1.1.6 is what most users run on Tahoe, and its output is currently unusable for scripting: empty manufacturer fields, buses reported as `Bus 000` with empty product IDs, unstable device numbers, a `-s` filter that never matches, and a tree mode that prints raw sort keys. This PR makes the output match the pre-Tahoe format and the Linux lsusb conventions the script advertises.

## How Has This Been Tested?

- **Tahoe 26.5.1, Apple Silicon, physical hardware** with 7 buses and 18 devices including 4 levels of hub nesting: flat listing, `-t` tree (hierarchy and indentation verified against the physical topology), `-s 8:`, `-s 8:1`, `-p -d 0403:6001`, `-d` with no match (exit 1), bare run (exit 0).
- **Pre-Tahoe regression:** since `setup()` only populates `$rawlog` when unset, both this branch and 1.1.6 were run against a canned Sonoma-format `SPUSBDataType` fixture (Intel-style `Bus Number:` lines, `/ devnum` location suffixes, a `Media:`/`Volumes:` storage device, nested hubs). The fixed version parses device numbers (002/005/003), bus numbers (020/026), manufacturers, tree depths, filters, and exit codes correctly; 1.1.6 printed five garbage device lines, a broken `IPCI` root hub, and unstripped tree sort keys on the same input.
- `shellcheck` clean; `bash -n` clean.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Testing update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Dependencies update
- [ ] Security update

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
- [ ] I have included breaking change notes for the next release
- [x] I verified my changes on target platforms/environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
