### PR TITLE
fix: quote command substitutions and disable shellcheck warning for word splitting in loops

### DIFF
--- a/lsusb
+++ b/lsusb
@@ -4,6 +4,7 @@
 # Author: LanikSJ, Oct 2023 - 2025
 #
 # Disclaimer: Usage info and functionality from lsusb under Linux
+# shellcheck disable=SC2066
 
 # Turn on extended patterns
 shopt -s extglob
@@ -351,7 +352,7 @@ tree() {
   setup
   treeflag="yes"
 
-  for device in $(get_devices); do
+  for device in "$(get_devices)"; do
     # Skip null device lines
     if [ "${#device}" != 1 ]; then
       parse
@@ -360,7 +361,7 @@ tree() {
     fi
   done
 
-  for device in $(get_buses); do
+  for device in "$(get_buses)"; do
     parse
     buildtreeline
     treedata="$treedata""$treeline"$'\n'
@@ -427,14 +428,14 @@ setup
 # will not be interfered
 
 # Iterate over each entry
-for device in $(get_devices); do
+for device in "$(get_devices)"; do
   if parse; then
     # Print the formatted entry
     echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"
   fi
 done
 
-for device in $(get_buses); do
+for device in "$(get_buses)"; do
   if parse; then
     # Print the formatted entry
     echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"


### PR DESCRIPTION
- add quote command subsitutions per restyled
- disable shellcheck warning for word splitting in loops
