### PR TITLE
Revert "fix: quote command substitutions and disable shellcheck warning for word splitting in loops (#157)"

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -4,4 +4,4 @@ also_exclude:
 
 restylers:
   - shellharden:
-    enabled: false
+      enabled: false

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,7 @@
+also_exclude:
+  - doc/**/*
+  - .github/**/*
+
+restylers:
+  - shellharden:
+    enabled: false

--- a/lsusb
+++ b/lsusb
@@ -4,7 +4,6 @@
 # Author: LanikSJ, Oct 2023 - 2025
 #
 # Disclaimer: Usage info and functionality from lsusb under Linux
-# shellcheck disable=SC2066
 
 # Turn on extended patterns
 shopt -s extglob
@@ -352,7 +351,7 @@ tree() {
   setup
   treeflag="yes"
 
-  for device in "$(get_devices)"; do
+  for device in $(get_devices); do
     # Skip null device lines
     if [ "${#device}" != 1 ]; then
       parse
@@ -361,7 +360,7 @@ tree() {
     fi
   done
 
-  for device in "$(get_buses)"; do
+  for device in $(get_buses); do
     parse
     buildtreeline
     treedata="$treedata""$treeline"$'\n'
@@ -428,14 +427,14 @@ setup
 # will not be interfered
 
 # Iterate over each entry
-for device in "$(get_devices)"; do
+for device in $(get_devices); do
   if parse; then
     # Print the formatted entry
     echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"
   fi
 done
 
-for device in "$(get_buses)"; do
+for device in $(get_buses); do
   if parse; then
     # Print the formatted entry
     echo "Bus ""$bus_num"" Device ""$device_num"": ID ""$VID"":""$PID"" ""$manufacturer"" ""$name"" ""$serial_str"


### PR DESCRIPTION
…ng for word splitting in loops (#157)"

This reverts commit 0c37c71c527dd70d9ee68a1989661ff4246f520b.