### PR TITLE
chore(lint): migrate markdownlint configuration to TOML

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-    "default": true,
-    "MD013": {
-        "line_length": 120
-    },
-    "MD041": false
-}

--- a/.markdownlint.toml
+++ b/.markdownlint.toml
@@ -1,0 +1,6 @@
+default = true
+
+[MD013]
+line_length = 120
+
+MD041 = false


### PR DESCRIPTION
Replaces the JSON markdownlint configuration with an equivalent TOML file, keeping the same rules.

- Removes `.markdownlint.json`
- Adds `.markdownlint.toml` with identical rule settings
